### PR TITLE
fix css img selector affecting image width

### DIFF
--- a/django/db/static/css/hmslincs.css
+++ b/django/db/static/css/hmslincs.css
@@ -69,7 +69,7 @@
   float: right;
   width:200px;
 }
-img:not(.compound_image_thumbnail .compound_image){
+img:not(.compound_image_thumbnail):not(.compound_image){
 	max-width: 100%;
 	height: auto;
 }


### PR DESCRIPTION
This fixes the image sizing issue with the kinomescan images in the small molecule views.
