### PR TITLE
resolves #309 small molecule detail hides datasets if there is 1 batch

### DIFF
--- a/django/db/views.py
+++ b/django/db/views.py
@@ -611,14 +611,10 @@ def smallMoleculeDetail(request, facility_salt_id):
                 details['attached_files'] = AttachedFileTable(attachedFiles)
             
         # batch table
-        if smb == None:
+        if not smb:
             batches = SmallMoleculeBatch.objects.filter(smallmolecule=sm)
-            if(len(batches)>1):
-                details['batchTable']=SmallMoleculeBatchTable(batches)
-            elif(len(batches)==1):
-                # if there is only one batch, then show details for it
-                smb = batches[0]
-        if smb:
+            details['batchTable']=SmallMoleculeBatchTable(batches)
+        else:
             details['smallmolecule_batch']= get_detail(
                 smb,['smallmoleculebatch',''])
             details['facility_salt_batch'] = '%s-%s-%s' % (sm.facility_id,sm.salt_id,smb.facility_batch_id) 


### PR DESCRIPTION
- only send the batch to the template if the explicit batch URL is called

@dwrobel1 
@jmuhlich 

a test case: http://dev.lincs.hms.harvard.edu/db/sm/10270-101/