### PR TITLE
Removed duplicate python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,10 @@ ipython #==0.13
 Jinja2 #==2.7.2
 lxml>=3.3.0
 matplotlib #==1.2.0
-openpyxl
 # pandas  # this is too big, and only needed for single-cell-dynamics at build time anyway
 psycopg2 #==2.4.5
 requests #==0.14.1
 xlrd #==0.8.0
 xlwt #==0.7.4
-django-webtemplates #==0.1.2
 openpyxl>=1.8
 Wand #==0.3.5


### PR DESCRIPTION
pip does not accept requirements files with ambiguity, so removed them.

In the case of openpyxl, use the version restricted option of the two previous requirements.