### PR TITLE
fix search query reagent to sub table joins

### DIFF
--- a/django/db/views.py
+++ b/django/db/views.py
@@ -1738,9 +1738,12 @@ class SearchManager(models.Manager):
             params.append(ids)
 
         criteria += ' ) '
+        # force join to the reagent table so that it is available in all orm use cases
+        criteria += ' AND db_reagent.id=%s.reagent_ptr_id' % tablename
         where = [criteria]
                 
         queryset = base_query.extra(
+            tables=['db_reagent'],
             select=extra_select,
             where=where,
             params=params,


### PR DESCRIPTION
fix: force join from sub table to the base table when using the extra query clause:
* some ORM count use cases do not auto join the sub table to the base table
* this fix makes this join explicit in all cases
* fixes the specific use case where count is performed on a query having the where clause:

`(sub)reagent.search_vector @@ to_tsquery(search) or "db_reagent"."search_vector" @@ to_tsquery(search)`