### PR TITLE
Disable makeimg step in deploy

### DIFF
--- a/deploy
+++ b/deploy
@@ -376,7 +376,7 @@ deployed by $USER ($UID) connected from $ssh_client
 EOF
 
   maybe_activate_virtualenv
-  gitpull && runpip && builddb && makeimg && collectstatic && killfcgi
+  gitpull && runpip && builddb && collectstatic && killfcgi
 
   STATUS=$SUCCESS
   echo done


### PR DESCRIPTION
This isn't needed anymore with the new build process for the explore apps. Their build steps do need to be added to the deploy script but this change will fix the immediate problem of deploy breaking.