### PR TITLE
display an empty string for empty molecular_weight field

### DIFF
--- a/django/db/models.py
+++ b/django/db/models.py
@@ -496,7 +496,8 @@ class SmallMoleculeBatch(ReagentBatch):
       
     def get_molecular_weight(self, is_authenticated=False):
         if(not self.reagent.is_restricted or is_authenticated):
-            return str(self._molecular_weight).rstrip('0')
+            return ( str(self._molecular_weight).rstrip('0') 
+                        if self._molecular_weight else '' )
         else:
             return 0
 

--- a/django/db/models.py
+++ b/django/db/models.py
@@ -497,7 +497,7 @@ class SmallMoleculeBatch(ReagentBatch):
     def get_molecular_weight(self, is_authenticated=False):
         if(not self.reagent.is_restricted or is_authenticated):
             return ( str(self._molecular_weight).rstrip('0') 
-                        if self._molecular_weight else '' )
+                        if self._molecular_weight is not None else '' )
         else:
             return 0
 


### PR DESCRIPTION
- display null values in the molecular weight field as empty strings (not "None")

@jmuhlich this should be ready for production